### PR TITLE
Fix typo, rename cuttentTime to currentTime

### DIFF
--- a/packages/hoppscotch-common/src/helpers/preRequestScriptSnippets.ts
+++ b/packages/hoppscotch-common/src/helpers/preRequestScriptSnippets.ts
@@ -7,8 +7,8 @@ pw.env.set("variable", "value");`,
   {
     name: "Environment: Set timestamp variable",
     script: `\n\n// Set timestamp variable
-const cuttentTime = Date.now();
-pw.env.set("timestamp", cuttentTime.toString());`,
+const currentTime = Date.now();
+pw.env.set("timestamp", currentTime.toString());`,
   },
   {
     name: "Environment: Set random number variable",


### PR DESCRIPTION
Fixes a typo in the preRequestScriptSnippets.ts file. cuttentTime -> currentTime

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

### Description
<!-- Add a brief description of the pull request -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
